### PR TITLE
Initializing participants with existing secrets + Test

### DIFF
--- a/tests/happy_path.rs
+++ b/tests/happy_path.rs
@@ -28,7 +28,7 @@ fn three_participants_curve25519() {
 #[test]
 fn three_participants_bls12381() {
     three_participants::<bls12_381_plus::G1Projective>();
-    // three_participants::<bls12_381_plus::G2Projective>();
+    three_participants::<bls12_381_plus::G2Projective>();
 }
 
 fn three_participants<G: Group + GroupEncoding + Default>() {
@@ -109,19 +109,16 @@ fn three_participants<G: Group + GroupEncoding + Default>() {
 
     for p in &participants {
         assert!(p.round5(&r4bdata).is_ok());
-        // println!("Old publicKey- {:?}", p.get_public_key().unwrap());
     }
 
-    // println!("Pubkey match (1, 2)- {}", participants[0].get_public_key().unwrap() == participants[1].get_public_key().unwrap());
     assert!(participants[0].get_public_key().unwrap() == participants[1].get_public_key().unwrap());
-    // println!("Pubkey match (2, 3)- {}", participants[1].get_public_key().unwrap() == participants[2].get_public_key().unwrap());
     assert!(participants[1].get_public_key().unwrap() == participants[2].get_public_key().unwrap());
 
     let res = combine_shares::<G::Scalar, u8, Vec<u8>>(&r4shares);
     assert!(res.is_ok());
     let secret = res.unwrap();
-    println!("Old Secret- {:?}", secret);
-    println!("Old Public - {:?}", (G::generator() * secret).to_bytes().as_ref());
+
+    // println!("Old Public - {:?}", (G::generator() * secret).to_bytes().as_ref());
 
     assert_eq!(r4bdata[&1].public_key, G::generator() * secret);
     assert_eq!(r4bdata[&2].public_key, G::generator() * secret);
@@ -139,7 +136,7 @@ fn three_participants<G: Group + GroupEncoding + Default>() {
     ];
     let s1 = lagrange_interpolation::<G>(participants[0].get_secret_share().unwrap(), &share_ids, 0);
     let s2 = lagrange_interpolation::<G>(participants[1].get_secret_share().unwrap(), &share_ids, 1);
-    let s3 = lagrange_interpolation::<G>(participants[1].get_secret_share().unwrap(), &share_ids, 2);
+    let s3 = lagrange_interpolation::<G>(participants[2].get_secret_share().unwrap(), &share_ids, 2);
 
     let mut participants = [
         SecretParticipant::<G>::with_secret(NonZeroUsize::new(1).unwrap(), s1, parameters).unwrap(),
@@ -245,36 +242,28 @@ fn three_participants<G: Group + GroupEncoding + Default>() {
     // Round 5
     for p in &participants {
         assert!(p.round5(&r4bdata).is_ok());
-        // println!("New publicKey- {:?}", p.get_public_key().unwrap());
     }
 
     assert!(new_participant.round5(&r4bdata).is_ok());
-    // println!("New publicKey- {:?}", new_participant.get_public_key().unwrap());
 
-    println!("New Pubkey match (1, 2)- {}", participants[0].get_public_key().unwrap() == participants[1].get_public_key().unwrap());
     assert!(participants[0].get_public_key().unwrap() == participants[1].get_public_key().unwrap());
-    println!("New Pubkey match (2, 3)- {}", participants[1].get_public_key().unwrap() == participants[2].get_public_key().unwrap());
     assert!(participants[1].get_public_key().unwrap() == participants[2].get_public_key().unwrap());
-
-    // Public key doesn't match
-    println!("New Pubkey match (3, 4)- {}", participants[2].get_public_key().unwrap() == new_participant.get_public_key().unwrap());
-    // assert!(participants[2].get_public_key().unwrap() == new_participant.get_public_key().unwrap());
-
-    // Public key doesn't match
-    println!("New Pubkey match (4, 0)- {}", participants[0].get_public_key().unwrap() == new_participant.get_public_key().unwrap());
-    println!("New public key {:?}", new_participant.get_public_key().unwrap().to_bytes().as_ref());
-    // assert!(participants[0].get_public_key().unwrap() == new_participant.get_public_key().unwrap());
+    assert!(participants[2].get_public_key().unwrap() == new_participant.get_public_key().unwrap());
+    assert!(participants[0].get_public_key().unwrap() == new_participant.get_public_key().unwrap());
 
     let res = combine_shares::<G::Scalar, u8, Vec<u8>>(&r4shares);
     assert!(res.is_ok());
-    let secret = res.unwrap();
-    println!("New Secret- {:?}", secret);
+    let new_secret = res.unwrap();
+
+    // println!("New Public - {:?}", (G::generator() * secret).to_bytes().as_ref());
 
     assert_eq!(r4bdata[&1].public_key, G::generator() * secret);
     assert_eq!(r4bdata[&2].public_key, G::generator() * secret);
     assert_eq!(r4bdata[&3].public_key, G::generator() * secret);
-    // Pubkey doesn't match
     assert_eq!(r4bdata[&4].public_key, G::generator() * secret);
+
+    // Old shared secret remains unchanged
+    assert_eq!(secret, new_secret);
 }
 
 

--- a/tests/happy_path.rs
+++ b/tests/happy_path.rs
@@ -1,4 +1,3 @@
-use bls12_381_plus::elliptic_curve::Curve;
 use gennaro_dkg::*;
 use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
@@ -134,14 +133,29 @@ fn three_participants<G: Group + GroupEncoding + Default>() {
         G::Scalar::from(2),
         G::Scalar::from(3),
     ];
-    let s1 = lagrange_interpolation::<G>(participants[0].get_secret_share().unwrap(), &share_ids, 0);
-    let s2 = lagrange_interpolation::<G>(participants[1].get_secret_share().unwrap(), &share_ids, 1);
-    let s3 = lagrange_interpolation::<G>(participants[2].get_secret_share().unwrap(), &share_ids, 2);
 
     let mut participants = [
-        SecretParticipant::<G>::with_secret(NonZeroUsize::new(1).unwrap(), s1, parameters).unwrap(),
-        SecretParticipant::<G>::with_secret(NonZeroUsize::new(2).unwrap(), s2, parameters).unwrap(),
-        SecretParticipant::<G>::with_secret(NonZeroUsize::new(3).unwrap(), s3, parameters).unwrap(),
+        SecretParticipant::<G>::with_secret(
+            NonZeroUsize::new(1).unwrap(),
+            parameters,
+            participants[0].get_secret_share().unwrap(), 
+            &share_ids,
+            0)
+        .unwrap(),
+        SecretParticipant::<G>::with_secret(
+            NonZeroUsize::new(2).unwrap(),
+            parameters,
+            participants[1].get_secret_share().unwrap(), 
+            &share_ids,
+            1)
+        .unwrap(),
+        SecretParticipant::<G>::with_secret(
+            NonZeroUsize::new(3).unwrap(),
+            parameters,
+            participants[2].get_secret_share().unwrap(), 
+            &share_ids,
+            2)
+        .unwrap(),
     ];
     let mut new_participant = RefreshParticipant::<G>::new(NonZeroUsize::new(4).unwrap(), parameters).unwrap();
 
@@ -264,19 +278,4 @@ fn three_participants<G: Group + GroupEncoding + Default>() {
 
     // Old shared secret remains unchanged
     assert_eq!(secret, new_secret);
-}
-
-
-fn lagrange_interpolation<G: Group + GroupEncoding + Default>(share: G::Scalar, shares_ids: &[G::Scalar], index: usize) -> G::Scalar {
-    use bls12_381_plus::elliptic_curve::Field;
-
-    let mut basis = G::Scalar::ONE;
-    for (j, x_j) in shares_ids.iter().enumerate() {
-        if j == index {
-            continue;
-        }
-        let denominator = *x_j - shares_ids[index];
-        basis *= *x_j * denominator.invert().unwrap();
-    }
-    basis * share
 }

--- a/tests/happy_path.rs
+++ b/tests/happy_path.rs
@@ -13,115 +13,143 @@ mod init_dkg {
     use super::*;
 
     #[test]
-    fn three_participants_k256() {
-        three_participants_init::<k256::ProjectivePoint>();
+    fn five_participants_k256() {
+        five_participants_init::<k256::ProjectivePoint>();
     }
 
     #[test]
-    fn three_participants_p256() {
-        three_participants_init::<p256::ProjectivePoint>();
+    fn five_participants_p256() {
+        five_participants_init::<p256::ProjectivePoint>();
     }
 
     #[test]
-    fn three_participants_curve25519() {
-        three_participants_init::<WrappedRistretto>();
-        three_participants_init::<WrappedEdwards>();
+    fn five_participants_curve25519() {
+        five_participants_init::<WrappedRistretto>();
+        five_participants_init::<WrappedEdwards>();
     }
 
     #[test]
-    fn three_participants_bls12381() {
-        three_participants_init::<bls12_381_plus::G1Projective>();
-        three_participants_init::<bls12_381_plus::G2Projective>();
+    fn five_participants_bls12381() {
+        five_participants_init::<bls12_381_plus::G1Projective>();
+        five_participants_init::<bls12_381_plus::G2Projective>();
     }
 }
 
-// Previous threshold was 2
+// Previous threshold was 3
 #[cfg(test)]
 mod add_participant_same_threshold {
     use super::*;
 
     #[test]
-    fn three_participants_k256() {
-        three_participants_add_participant::<k256::ProjectivePoint>(2);
+    fn five_participants_k256() {
+        five_participants_add_participant::<k256::ProjectivePoint>(3);
     }
 
     #[test]
-    fn three_participants_p256() {
-        three_participants_add_participant::<p256::ProjectivePoint>(2);
+    fn five_participants_p256() {
+        five_participants_add_participant::<p256::ProjectivePoint>(3);
     }
 
     #[test]
-    fn three_participants_curve25519() {
-        three_participants_add_participant::<WrappedRistretto>(2);
-        three_participants_add_participant::<WrappedEdwards>(2);
+    fn five_participants_curve25519() {
+        five_participants_add_participant::<WrappedRistretto>(3);
+        five_participants_add_participant::<WrappedEdwards>(3);
     }
 
     #[test]
-    fn three_participants_bls12381() {
-        three_participants_add_participant::<bls12_381_plus::G1Projective>(2);
-        three_participants_add_participant::<bls12_381_plus::G2Projective>(2);
+    fn five_participants_bls12381() {
+        five_participants_add_participant::<bls12_381_plus::G1Projective>(3);
+        five_participants_add_participant::<bls12_381_plus::G2Projective>(3);
     }
 }
 
-// Previous threshold was 2, new threshold is 1 more
+// Previous threshold was 3, new threshold is 5
 #[cfg(test)]
 mod add_participant_increase_threshold {
     use super::*;
 
     #[test]
-    fn three_participants_k256() {
-        three_participants_add_participant::<k256::ProjectivePoint>(3);
+    fn five_participants_k256() {
+        five_participants_add_participant::<k256::ProjectivePoint>(5);
     }
 
     #[test]
-    fn three_participants_p256() {
-        three_participants_add_participant::<p256::ProjectivePoint>(3);
+    fn five_participants_p256() {
+        five_participants_add_participant::<p256::ProjectivePoint>(5);
     }
 
     #[test]
-    fn three_participants_curve25519() {
-        three_participants_add_participant::<WrappedRistretto>(3);
-        three_participants_add_participant::<WrappedEdwards>(3);
+    fn five_participants_curve25519() {
+        five_participants_add_participant::<WrappedRistretto>(5);
+        five_participants_add_participant::<WrappedEdwards>(5);
     }
 
     #[test]
-    fn three_participants_bls12381() {
-        three_participants_add_participant::<bls12_381_plus::G1Projective>(3);
-        three_participants_add_participant::<bls12_381_plus::G2Projective>(3);
+    fn five_participants_bls12381() {
+        five_participants_add_participant::<bls12_381_plus::G1Projective>(5);
+        five_participants_add_participant::<bls12_381_plus::G2Projective>(5);
     }
 }
 
-// Previous threshold was 2
+// Previous threshold was 3
 #[cfg(test)]
 mod remove_participant_same_threshold {
     use super::*;
 
     #[test]
-    fn three_participants_k256() {
-        three_participants_remove_participant::<k256::ProjectivePoint>(2);
+    fn five_participants_k256() {
+        five_participants_remove_participant::<k256::ProjectivePoint>(3);
     }
 
     #[test]
-    fn three_participants_p256() {
-        three_participants_remove_participant::<p256::ProjectivePoint>(2);
+    fn five_participants_p256() {
+        five_participants_remove_participant::<p256::ProjectivePoint>(3);
     }
 
     #[test]
-    fn three_participants_curve25519() {
-        three_participants_remove_participant::<WrappedRistretto>(2);
-        three_participants_remove_participant::<WrappedEdwards>(2);
+    fn five_participants_curve25519() {
+        five_participants_remove_participant::<WrappedRistretto>(3);
+        five_participants_remove_participant::<WrappedEdwards>(3);
     }
 
     #[test]
-    fn three_participants_bls12381() {
-        three_participants_remove_participant::<bls12_381_plus::G1Projective>(2);
-        three_participants_remove_participant::<bls12_381_plus::G2Projective>(2);
+    fn five_participants_bls12381() {
+        five_participants_remove_participant::<bls12_381_plus::G1Projective>(3);
+        five_participants_remove_participant::<bls12_381_plus::G2Projective>(3);
     }
 }
 
-fn three_participants_init<G: Group + GroupEncoding + Default>() -> (Vec<SecretParticipant<G>>, <G as Group>::Scalar) {
-    const THRESHOLD: usize = 2;
-    const LIMIT: usize = 3;
+// Previous threshold was 3, new threshold is 2
+#[cfg(test)]
+mod remove_participant_decrease_threshold {
+    use super::*;
+
+    #[test]
+    fn five_participants_k256() {
+        five_participants_remove_participant::<k256::ProjectivePoint>(2);
+    }
+
+    #[test]
+    fn five_participants_p256() {
+        five_participants_remove_participant::<p256::ProjectivePoint>(2);
+    }
+
+    #[test]
+    fn five_participants_curve25519() {
+        five_participants_remove_participant::<WrappedRistretto>(2);
+        five_participants_remove_participant::<WrappedEdwards>(2);
+    }
+
+    #[test]
+    fn five_participants_bls12381() {
+        five_participants_remove_participant::<bls12_381_plus::G1Projective>(2);
+        five_participants_remove_participant::<bls12_381_plus::G2Projective>(2);
+    }
+}
+
+fn five_participants_init<G: Group + GroupEncoding + Default>() -> (Vec<SecretParticipant<G>>, <G as Group>::Scalar) {
+    const THRESHOLD: usize = 3;
+    const LIMIT: usize = 5;
 
     let threshold = NonZeroUsize::new(THRESHOLD).unwrap();
     let limit = NonZeroUsize::new(LIMIT).unwrap();
@@ -130,6 +158,8 @@ fn three_participants_init<G: Group + GroupEncoding + Default>() -> (Vec<SecretP
         SecretParticipant::<G>::new(NonZeroUsize::new(1).unwrap(), parameters).unwrap(),
         SecretParticipant::<G>::new(NonZeroUsize::new(2).unwrap(), parameters).unwrap(),
         SecretParticipant::<G>::new(NonZeroUsize::new(3).unwrap(), parameters).unwrap(),
+        SecretParticipant::<G>::new(NonZeroUsize::new(4).unwrap(), parameters).unwrap(),
+        SecretParticipant::<G>::new(NonZeroUsize::new(5).unwrap(), parameters).unwrap(),
     ];
 
     let mut r1bdata = Vec::with_capacity(LIMIT);
@@ -201,6 +231,9 @@ fn three_participants_init<G: Group + GroupEncoding + Default>() -> (Vec<SecretP
 
     assert!(participants[0].get_public_key().unwrap() == participants[1].get_public_key().unwrap());
     assert!(participants[1].get_public_key().unwrap() == participants[2].get_public_key().unwrap());
+    assert!(participants[2].get_public_key().unwrap() == participants[3].get_public_key().unwrap());
+    assert!(participants[3].get_public_key().unwrap() == participants[4].get_public_key().unwrap());
+    assert!(participants[4].get_public_key().unwrap() == participants[1].get_public_key().unwrap());
 
     let res = combine_shares::<G::Scalar, u8, Vec<u8>>(&r4shares);
     assert!(res.is_ok());
@@ -211,25 +244,30 @@ fn three_participants_init<G: Group + GroupEncoding + Default>() -> (Vec<SecretP
     assert_eq!(r4bdata[&1].public_key, G::generator() * secret);
     assert_eq!(r4bdata[&2].public_key, G::generator() * secret);
     assert_eq!(r4bdata[&3].public_key, G::generator() * secret);
+    assert_eq!(r4bdata[&4].public_key, G::generator() * secret);
+    assert_eq!(r4bdata[&5].public_key, G::generator() * secret);
 
     (participants, secret)
 }
 
-fn three_participants_add_participant<G: Group + GroupEncoding + Default>(threshold: usize) {
-    let (participants, secret) = three_participants_init::<G>();
+fn five_participants_add_participant<G: Group + GroupEncoding + Default>(threshold: usize) {
+    let (participants, secret) = five_participants_init::<G>();
 
     // Next epoch
     let THRESHOLD: usize = threshold;
-    const LIMIT: usize = 3;
+    const LIMIT: usize = 5;
+    const INCREMENT: usize = 2;
 
     let threshold = NonZeroUsize::new(THRESHOLD).unwrap();
-    let limit = NonZeroUsize::new(LIMIT + 1).unwrap();
+    let limit = NonZeroUsize::new(LIMIT + INCREMENT).unwrap();
     let parameters = Parameters::<G>::new(threshold, limit);
 
     let share_ids = [
         G::Scalar::from(1),
         G::Scalar::from(2),
         G::Scalar::from(3),
+        G::Scalar::from(4),
+        G::Scalar::from(5),
     ];
 
     let mut participants = [
@@ -254,25 +292,46 @@ fn three_participants_add_participant<G: Group + GroupEncoding + Default>(thresh
             &share_ids,
             2)
         .unwrap(),
+        SecretParticipant::<G>::with_secret(
+            NonZeroUsize::new(4).unwrap(),
+            parameters,
+            participants[3].get_secret_share().unwrap(), 
+            &share_ids,
+            3)
+        .unwrap(),
+        SecretParticipant::<G>::with_secret(
+            NonZeroUsize::new(5).unwrap(),
+            parameters,
+            participants[4].get_secret_share().unwrap(), 
+            &share_ids,
+            4)
+        .unwrap(),
     ];
-    let mut new_participant = RefreshParticipant::<G>::new(NonZeroUsize::new(4).unwrap(), parameters).unwrap();
+    let mut new_participants = [
+        RefreshParticipant::<G>::new(NonZeroUsize::new(6).unwrap(), parameters).unwrap(),
+        RefreshParticipant::<G>::new(NonZeroUsize::new(7).unwrap(), parameters).unwrap(),
+    ];
 
     // Round 1
-    let mut r1bdata = Vec::with_capacity(LIMIT + 1);
-    let mut r1p2pdata = Vec::with_capacity(LIMIT + 1);
+    let mut r1bdata = Vec::with_capacity(LIMIT + INCREMENT);
+    let mut r1p2pdata = Vec::with_capacity(LIMIT + INCREMENT);
     for p in participants.iter_mut() {
         let (broadcast, p2p) = p.round1().expect("Round 1 should work");
         r1bdata.push(broadcast);
         r1p2pdata.push(p2p);
     }
-    let (broadcast, p2p) = new_participant.round1().expect("Round 1 should work");
-    r1bdata.push(broadcast);
-    r1p2pdata.push(p2p);
+    for p in new_participants.iter_mut() {
+        let (broadcast, p2p) = p.round1().expect("Round 1 should work");
+        r1bdata.push(broadcast);
+        r1p2pdata.push(p2p);
+    }
 
     for p in participants.iter_mut() {
         assert!(p.round1().is_err());
     }
-    assert!(new_participant.round1().is_err());
+    for p in new_participants.iter_mut() {
+        assert!(p.round1().is_err());
+    }
 
     // Round 2
     let mut r2bdata = BTreeMap::new();
@@ -291,30 +350,44 @@ fn three_participants_add_participant<G: Group + GroupEncoding + Default>(thresh
             bdata.insert(id, r1bdata[id - 1].clone());
             p2pdata.insert(id, r1p2pdata[id - 1][&my_id].clone());
         }
-        let id = new_participant.get_id();
-        bdata.insert(id, r1bdata[id - 1].clone());
-        p2pdata.insert(id, r1p2pdata[id - 1][&my_id].clone());
+        for j in 0..INCREMENT {
+            let pp = &new_participants[j];
+            let id = pp.get_id();
+            bdata.insert(id, r1bdata[id - 1].clone());
+            p2pdata.insert(id, r1p2pdata[id - 1][&my_id].clone());
+        }
 
         let p = &mut participants[i];
         let res = p.round2(bdata, p2pdata);
         assert!(res.is_ok());
         r2bdata.insert(my_id, res.unwrap());
     }
+    for i in 0..INCREMENT {
+        let mut bdata = BTreeMap::new();
+        let mut p2pdata = BTreeMap::new();
 
-    let mut bdata = BTreeMap::new();
-    let mut p2pdata = BTreeMap::new();
+        let my_id = new_participants[i].get_id();
+        for j in 0..LIMIT {
+            let pp = &participants[j];
+            let id = pp.get_id();
+            bdata.insert(id, r1bdata[id - 1].clone());
+            p2pdata.insert(id, r1p2pdata[id - 1][&my_id].clone());
+        }
+        for j in 0..INCREMENT {
+            let pp = &new_participants[j];
+            let id = pp.get_id();
+            if my_id == id {
+                continue;
+            }
+            bdata.insert(id, r1bdata[id - 1].clone());
+            p2pdata.insert(id, r1p2pdata[id - 1][&my_id].clone());
+        }
 
-    let my_id = new_participant.get_id();
-    for j in 0..LIMIT {
-        let pp = &participants[j];
-        let id = pp.get_id();
-        bdata.insert(id, r1bdata[id - 1].clone());
-        p2pdata.insert(id, r1p2pdata[id - 1][&my_id].clone());
+        let p = &mut new_participants[i];
+        let res = p.round2(bdata, p2pdata);
+        assert!(res.is_ok());
+        r2bdata.insert(my_id, res.unwrap());
     }
-
-    let res = new_participant.round2(bdata, p2pdata);
-    assert!(res.is_ok());
-    r2bdata.insert(my_id, res.unwrap());
 
     // Round 3
     let mut r3bdata = BTreeMap::new();
@@ -324,15 +397,16 @@ fn three_participants_add_participant<G: Group + GroupEncoding + Default>(thresh
         r3bdata.insert(p.get_id(), res.unwrap());
         assert!(p.round3(&r2bdata).is_err());
     }
-
-    let res = new_participant.round3(&r2bdata);
-    assert!(res.is_ok());
-    r3bdata.insert(new_participant.get_id(), res.unwrap());
-    assert!(new_participant.round3(&r2bdata).is_err());
+    for p in new_participants.iter_mut() {
+        let res = p.round3(&r2bdata);
+        assert!(res.is_ok());
+        r3bdata.insert(p.get_id(), res.unwrap());
+        assert!(p.round3(&r2bdata).is_err());
+    }
 
     // Round 4
     let mut r4bdata = BTreeMap::new();
-    let mut r4shares = Vec::with_capacity(LIMIT + 1);
+    let mut r4shares = Vec::with_capacity(LIMIT + INCREMENT);
     for p in participants.iter_mut() {
         let res = p.round4(&r3bdata);
         assert!(res.is_ok());
@@ -342,26 +416,31 @@ fn three_participants_add_participant<G: Group + GroupEncoding + Default>(thresh
         r4shares.push(<Vec<u8> as Share>::from_field_element(p.get_id() as u8, share).unwrap());
         assert!(p.round4(&r3bdata).is_err());
     }
-
-    let res = new_participant.round4(&r3bdata);
-    assert!(res.is_ok());
-    let bdata = res.unwrap();
-    let share = new_participant.get_secret_share().unwrap();
-    r4bdata.insert(new_participant.get_id(), bdata);
-    r4shares.push(<Vec<u8> as Share>::from_field_element(new_participant.get_id() as u8, share).unwrap());
-    assert!(new_participant.round4(&r3bdata).is_err());
+    for p in new_participants.iter_mut() {
+        let res = p.round4(&r3bdata);
+        assert!(res.is_ok());
+        let bdata = res.unwrap();
+        let share = p.get_secret_share().unwrap();
+        r4bdata.insert(p.get_id(), bdata);
+        r4shares.push(<Vec<u8> as Share>::from_field_element(p.get_id() as u8, share).unwrap());
+        assert!(p.round4(&r3bdata).is_err());
+    }
 
     // Round 5
     for p in &participants {
         assert!(p.round5(&r4bdata).is_ok());
     }
-
-    assert!(new_participant.round5(&r4bdata).is_ok());
+    for p in &new_participants {
+        assert!(p.round5(&r4bdata).is_ok());
+    }
 
     assert!(participants[0].get_public_key().unwrap() == participants[1].get_public_key().unwrap());
     assert!(participants[1].get_public_key().unwrap() == participants[2].get_public_key().unwrap());
-    assert!(participants[2].get_public_key().unwrap() == new_participant.get_public_key().unwrap());
-    assert!(participants[0].get_public_key().unwrap() == new_participant.get_public_key().unwrap());
+    assert!(participants[2].get_public_key().unwrap() == participants[3].get_public_key().unwrap());
+    assert!(participants[3].get_public_key().unwrap() == participants[4].get_public_key().unwrap());
+    assert!(participants[4].get_public_key().unwrap() == new_participants[0].get_public_key().unwrap());
+    assert!(new_participants[0].get_public_key().unwrap() == new_participants[1].get_public_key().unwrap());
+    assert!(new_participants[1].get_public_key().unwrap() == participants[0].get_public_key().unwrap());
 
     let res = combine_shares::<G::Scalar, u8, Vec<u8>>(&r4shares);
     assert!(res.is_ok());
@@ -373,17 +452,20 @@ fn three_participants_add_participant<G: Group + GroupEncoding + Default>(thresh
     assert_eq!(r4bdata[&2].public_key, G::generator() * secret);
     assert_eq!(r4bdata[&3].public_key, G::generator() * secret);
     assert_eq!(r4bdata[&4].public_key, G::generator() * secret);
+    assert_eq!(r4bdata[&5].public_key, G::generator() * secret);
+    assert_eq!(r4bdata[&6].public_key, G::generator() * secret);
+    assert_eq!(r4bdata[&7].public_key, G::generator() * secret);
 
     // Old shared secret remains unchanged
     assert_eq!(secret, new_secret);
 }
 
-fn three_participants_remove_participant<G: Group + GroupEncoding + Default>(threshold: usize) {
-    let (participants, secret) = three_participants_init::<G>();
+fn five_participants_remove_participant<G: Group + GroupEncoding + Default>(threshold: usize) {
+    let (participants, secret) = five_participants_init::<G>();
 
     // Next epoch
     let THRESHOLD: usize = threshold;
-    const LIMIT: usize = 2;
+    const LIMIT: usize = 3;
 
     let threshold = NonZeroUsize::new(THRESHOLD).unwrap();
     let limit = NonZeroUsize::new(LIMIT).unwrap();
@@ -392,6 +474,7 @@ fn three_participants_remove_participant<G: Group + GroupEncoding + Default>(thr
     let share_ids = [
         G::Scalar::from(1),
         G::Scalar::from(3),
+        G::Scalar::from(4),
     ];
 
     let mut participants = [
@@ -408,6 +491,13 @@ fn three_participants_remove_participant<G: Group + GroupEncoding + Default>(thr
             participants[2].get_secret_share().unwrap(), 
             &share_ids,
             1)
+        .unwrap(),
+        SecretParticipant::<G>::with_secret(
+            NonZeroUsize::new(3).unwrap(),
+            parameters,
+            participants[3].get_secret_share().unwrap(), 
+            &share_ids,
+            2)
         .unwrap(),
     ];
 
@@ -488,6 +578,7 @@ fn three_participants_remove_participant<G: Group + GroupEncoding + Default>(thr
 
     assert_eq!(r4bdata[&1].public_key, G::generator() * new_secret);
     assert_eq!(r4bdata[&2].public_key, G::generator() * new_secret);
+    assert_eq!(r4bdata[&3].public_key, G::generator() * new_secret);
 
     // Old shared secret remains unchanged
     assert_eq!(secret, new_secret);

--- a/tests/happy_path.rs
+++ b/tests/happy_path.rs
@@ -153,24 +153,51 @@ mod add_and_remove_participant_increase_participant {
 
     #[test]
     fn five_participants_k256() {
-        five_participants_add_and_remove_participant::<k256::ProjectivePoint>(5);
+        five_participants_add_and_remove_increase_participant::<k256::ProjectivePoint>(5);
     }
 
     #[test]
     fn five_participants_p256() {
-        five_participants_add_and_remove_participant::<p256::ProjectivePoint>(4);
+        five_participants_add_and_remove_increase_participant::<p256::ProjectivePoint>(4);
     }
 
     #[test]
     fn five_participants_curve25519() {
-        five_participants_add_and_remove_participant::<WrappedRistretto>(6);
-        five_participants_add_and_remove_participant::<WrappedEdwards>(2);
+        five_participants_add_and_remove_increase_participant::<WrappedRistretto>(6);
+        five_participants_add_and_remove_increase_participant::<WrappedEdwards>(2);
     }
 
     #[test]
     fn five_participants_bls12381() {
-        five_participants_add_and_remove_participant::<bls12_381_plus::G1Projective>(5);
-        five_participants_add_and_remove_participant::<bls12_381_plus::G2Projective>(2);
+        five_participants_add_and_remove_increase_participant::<bls12_381_plus::G1Projective>(5);
+        five_participants_add_and_remove_increase_participant::<bls12_381_plus::G2Projective>(2);
+    }
+}
+
+#[cfg(test)]
+mod add_and_remove_participant_decrease_participant {
+    use super::*;
+
+    #[test]
+    fn five_participants_k256() {
+        five_participants_add_and_remove_decrease_participant::<k256::ProjectivePoint>(3);
+    }
+
+    #[test]
+    fn five_participants_p256() {
+        five_participants_add_and_remove_decrease_participant::<p256::ProjectivePoint>(4);
+    }
+
+    #[test]
+    fn five_participants_curve25519() {
+        five_participants_add_and_remove_decrease_participant::<WrappedRistretto>(3);
+        five_participants_add_and_remove_decrease_participant::<WrappedEdwards>(2);
+    }
+
+    #[test]
+    fn five_participants_bls12381() {
+        five_participants_add_and_remove_decrease_participant::<bls12_381_plus::G1Projective>(3);
+        five_participants_add_and_remove_decrease_participant::<bls12_381_plus::G2Projective>(4);
     }
 }
 
@@ -611,7 +638,195 @@ fn five_participants_remove_participant<G: Group + GroupEncoding + Default>(thre
     assert_eq!(secret, new_secret);
 }
 
-fn five_participants_add_and_remove_participant<G: Group + GroupEncoding + Default>(threshold: usize) {
+fn five_participants_add_and_remove_decrease_participant<G: Group + GroupEncoding + Default>(threshold: usize) {
+    let (participants, secret) = five_participants_init::<G>();
+
+    // Next epoch
+    let THRESHOLD: usize = threshold;
+    const LIMIT: usize = 3;
+    const INCREMENT: usize = 1;
+
+    let threshold = NonZeroUsize::new(THRESHOLD).unwrap();
+    let limit = NonZeroUsize::new(LIMIT + INCREMENT).unwrap();
+    let parameters = Parameters::<G>::new(threshold, limit);
+
+    let share_ids = [
+        G::Scalar::from(2),
+        G::Scalar::from(3),
+        G::Scalar::from(4),
+    ];
+
+    let mut participants = [
+        SecretParticipant::<G>::with_secret(
+            NonZeroUsize::new(1).unwrap(),
+            parameters,
+            participants[1].get_secret_share().unwrap(), 
+            &share_ids,
+            0)
+        .unwrap(),
+        SecretParticipant::<G>::with_secret(
+            NonZeroUsize::new(2).unwrap(),
+            parameters,
+            participants[2].get_secret_share().unwrap(), 
+            &share_ids,
+            1)
+        .unwrap(),
+        SecretParticipant::<G>::with_secret(
+            NonZeroUsize::new(3).unwrap(),
+            parameters,
+            participants[3].get_secret_share().unwrap(), 
+            &share_ids,
+            2)
+        .unwrap(),
+    ];
+
+    let mut new_participants = [
+        RefreshParticipant::<G>::new(NonZeroUsize::new(4).unwrap(), parameters).unwrap(),
+    ];
+
+    // Round 1
+    let mut r1bdata = Vec::with_capacity(LIMIT + INCREMENT);
+    let mut r1p2pdata = Vec::with_capacity(LIMIT + INCREMENT);
+    for p in participants.iter_mut() {
+        let (broadcast, p2p) = p.round1().expect("Round 1 should work");
+        r1bdata.push(broadcast);
+        r1p2pdata.push(p2p);
+    }
+    for p in new_participants.iter_mut() {
+        let (broadcast, p2p) = p.round1().expect("Round 1 should work");
+        r1bdata.push(broadcast);
+        r1p2pdata.push(p2p);
+    }
+
+    for p in participants.iter_mut() {
+        assert!(p.round1().is_err());
+    }
+    for p in new_participants.iter_mut() {
+        assert!(p.round1().is_err());
+    }
+
+    // Round 2
+    let mut r2bdata = BTreeMap::new();
+
+    for i in 0..LIMIT {
+        let mut bdata = BTreeMap::new();
+        let mut p2pdata = BTreeMap::new();
+
+        let my_id = participants[i].get_id();
+        for j in 0..LIMIT {
+            let pp = &participants[j];
+            let id = pp.get_id();
+            if my_id == id {
+                continue;
+            }
+            bdata.insert(id, r1bdata[id - 1].clone());
+            p2pdata.insert(id, r1p2pdata[id - 1][&my_id].clone());
+        }
+        for j in 0..INCREMENT {
+            let pp = &new_participants[j];
+            let id = pp.get_id();
+            bdata.insert(id, r1bdata[id - 1].clone());
+            p2pdata.insert(id, r1p2pdata[id - 1][&my_id].clone());
+        }
+
+        let p = &mut participants[i];
+        let res = p.round2(bdata, p2pdata);
+        assert!(res.is_ok());
+        r2bdata.insert(my_id, res.unwrap());
+    }
+    for i in 0..INCREMENT {
+        let mut bdata = BTreeMap::new();
+        let mut p2pdata = BTreeMap::new();
+
+        let my_id = new_participants[i].get_id();
+        for j in 0..LIMIT {
+            let pp = &participants[j];
+            let id = pp.get_id();
+            bdata.insert(id, r1bdata[id - 1].clone());
+            p2pdata.insert(id, r1p2pdata[id - 1][&my_id].clone());
+        }
+        for j in 0..INCREMENT {
+            let pp = &new_participants[j];
+            let id = pp.get_id();
+            if my_id == id {
+                continue;
+            }
+            bdata.insert(id, r1bdata[id - 1].clone());
+            p2pdata.insert(id, r1p2pdata[id - 1][&my_id].clone());
+        }
+
+        let p = &mut new_participants[i];
+        let res = p.round2(bdata, p2pdata);
+        assert!(res.is_ok());
+        r2bdata.insert(my_id, res.unwrap());
+    }
+
+    // Round 3
+    let mut r3bdata = BTreeMap::new();
+    for p in participants.iter_mut() {
+        let res = p.round3(&r2bdata);
+        assert!(res.is_ok());
+        r3bdata.insert(p.get_id(), res.unwrap());
+        assert!(p.round3(&r2bdata).is_err());
+    }
+    for p in new_participants.iter_mut() {
+        let res = p.round3(&r2bdata);
+        assert!(res.is_ok());
+        r3bdata.insert(p.get_id(), res.unwrap());
+        assert!(p.round3(&r2bdata).is_err());
+    }
+
+    // Round 4
+    let mut r4bdata = BTreeMap::new();
+    let mut r4shares = Vec::with_capacity(LIMIT + INCREMENT);
+    for p in participants.iter_mut() {
+        let res = p.round4(&r3bdata);
+        assert!(res.is_ok());
+        let bdata = res.unwrap();
+        let share = p.get_secret_share().unwrap();
+        r4bdata.insert(p.get_id(), bdata);
+        r4shares.push(<Vec<u8> as Share>::from_field_element(p.get_id() as u8, share).unwrap());
+        assert!(p.round4(&r3bdata).is_err());
+    }
+    for p in new_participants.iter_mut() {
+        let res = p.round4(&r3bdata);
+        assert!(res.is_ok());
+        let bdata = res.unwrap();
+        let share = p.get_secret_share().unwrap();
+        r4bdata.insert(p.get_id(), bdata);
+        r4shares.push(<Vec<u8> as Share>::from_field_element(p.get_id() as u8, share).unwrap());
+        assert!(p.round4(&r3bdata).is_err());
+    }
+
+    // Round 5
+    for p in &participants {
+        assert!(p.round5(&r4bdata).is_ok());
+    }
+    for p in &new_participants {
+        assert!(p.round5(&r4bdata).is_ok());
+    }
+
+    assert!(participants[0].get_public_key().unwrap() == participants[1].get_public_key().unwrap());
+    assert!(participants[1].get_public_key().unwrap() == participants[2].get_public_key().unwrap());
+    assert!(participants[2].get_public_key().unwrap() == new_participants[0].get_public_key().unwrap());
+    assert!(new_participants[0].get_public_key().unwrap() == participants[0].get_public_key().unwrap());
+
+    let res = combine_shares::<G::Scalar, u8, Vec<u8>>(&r4shares);
+    assert!(res.is_ok());
+    let new_secret = res.unwrap();
+
+    // println!("New Public - {:?}", (G::generator() * secret).to_bytes().as_ref());
+
+    assert_eq!(r4bdata[&1].public_key, G::generator() * secret);
+    assert_eq!(r4bdata[&2].public_key, G::generator() * secret);
+    assert_eq!(r4bdata[&3].public_key, G::generator() * secret);
+    assert_eq!(r4bdata[&4].public_key, G::generator() * secret);
+
+    // Old shared secret remains unchanged
+    assert_eq!(secret, new_secret);
+}
+
+fn five_participants_add_and_remove_increase_participant<G: Group + GroupEncoding + Default>(threshold: usize) {
     let (participants, secret) = five_participants_init::<G>();
 
     // Next epoch
@@ -786,7 +1001,7 @@ fn five_participants_add_and_remove_participant<G: Group + GroupEncoding + Defau
     assert!(participants[2].get_public_key().unwrap() == new_participants[0].get_public_key().unwrap());
     assert!(new_participants[0].get_public_key().unwrap() == new_participants[1].get_public_key().unwrap());
     assert!(new_participants[1].get_public_key().unwrap() == new_participants[2].get_public_key().unwrap());
-    assert!(new_participants[2].get_public_key().unwrap() == participants[1].get_public_key().unwrap());
+    assert!(new_participants[2].get_public_key().unwrap() == participants[0].get_public_key().unwrap());
 
     let res = combine_shares::<G::Scalar, u8, Vec<u8>>(&r4shares);
     assert!(res.is_ok());


### PR DESCRIPTION
# Changes Made

- Initialize existing participants with Lagrange Interpolated shares
- Fixed the Refresh DKG test: Lagrange Interpolation for 3rd participant
- Add assertion for old & new secret comparison
- Update number of participants from 3 to 5 to allow more versatility in threshold changes in Refresh DKG
- Add new tests with increase & decrease thresholds:
  - Add participants
  - Remove participants
  - Add & Remove participants in the same Refresh DKG
- Organize them into modules:
  - init_dkg
  - add_participant_same_threshold
  - add_participant_increase_threshold
  - remove_participant_same_threshold
  - remove_participant_decrease_threshold
  - add_and_remove_participant_increase_participant
  - add_and_remove_participant_decrease_participant
- Remove print statements

# Suggested Improvements

## 1. A parent/wrapper for `SecretParticipant` & `RefreshParticipant`

Currently we have to use a separate vector to store the `RefreshParticipant`s which leads to a lot of code duplication. A common parent/trait that enables to treat the underlying participant as same will significantly reduce the code duplication in the tests & more importantly in the nodes.

**Caveat:** A parent enum might not be the best solution since we have to resort to match statements to use the underlying participant. This will lead to boilerplate code.

### Better Solutions

How about a Trait Object? Or using a Box pointer wrapper for SecretParticipantImpl & RefreshParticipant as `<Box<SecretParticipantImpl<G>>`?

## 2. Add native public_key comparison for all the curves used

We should also add a public_key comparison in the tests but seems like it can't be directly compared.

## 3. Tests should contain a parameter for number of participants

Refactor the tests using more generalized functions that can handle multiple SecretParticipants & RefreshParticipants by passing a parameter. This will significantly reduce the test boilerplate code.