### PR TITLE
feat: Implement Zeroize for P2P secrets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "1.0"
 serde = "1.0"
 uint-zigzag = { version = "0.2.1", features = ["std"] }
 vsss-rs = { version = "3.3", default-features = false, features = ["std"] }
+zeroize = "1.5.7"
 
 [dev-dependencies]
 bls12_381_plus = "0.8"


### PR DESCRIPTION
# What

Implement Zeroize & ZeroizeOnDrop traits for `Round1P2PData`: https://docs.rs/zeroize/latest/zeroize/#traits

# Test

Explicitly had to call `zeroize()` to assert that the secrets are indeed zeroed. Since we've implemented the ZeroizeOnDrop trait that should happen automatically when `Round1P2PData` goes out of scope. But in that case we can't assert it.
The same should happen in `Participant` struct's field: `round1_p2p_data: BTreeMap<usize, Round1P2PData>,`